### PR TITLE
[cy] add basic Welsh crawler

### DIFF
--- a/Lib/corpuscrawler/crawl_cy.py
+++ b/Lib/corpuscrawler/crawl_cy.py
@@ -1,0 +1,22 @@
+# coding: utf-8
+# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Curon Davies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from corpuscrawler.util import crawl_bbc_news, crawl_udhr
+
+def crawl(crawler):
+    out = crawler.get_output(language='cy')
+    crawl_udhr(crawler, out, filename='udhr_cym.txt')
+    crawl_bbc_news(crawler, out, urlprefix='/cymrufyw/')

--- a/Lib/corpuscrawler/main.py
+++ b/Lib/corpuscrawler/main.py
@@ -18,8 +18,9 @@ import sys
 from corpuscrawler import (
     crawl_ae, crawl_am, crawl_az, crawl_ar,
     crawl_be, crawl_bg,
-    crawl_bm, crawl_bn, crawl_bo, crawl_bs, crawl_ccp,
-    crawl_cs, crawl_de, crawl_dz, crawl_el, crawl_es,
+    crawl_bm, crawl_bn, crawl_bo, crawl_bs,
+    crawl_ccp, crawl_cs, crawl_cy,
+    crawl_de, crawl_dz, crawl_el, crawl_es,
     crawl_fa, crawl_fi, crawl_fit, crawl_fo, crawl_fuv,
     crawl_ga, crawl_gd, crawl_gsw, crawl_gv, crawl_ha,
     crawl_haw,
@@ -51,6 +52,7 @@ def main():
         'bs': crawl_bs.crawl,    # Bosnian
         'ccp': crawl_ccp.crawl,  # Chakma
         'cs': crawl_cs.crawl,    # Czech
+        'cy': crawl_cy.crawl,    # Welsh
         'de': crawl_de.crawl,    # German
         'dz': crawl_dz.crawl,    # Dzongkha
         'el': crawl_el.crawl,    # Greek


### PR DESCRIPTION
Tested with the following local change, to reduce redirects when run from the UK:

diff --git a/Lib/corpuscrawler/util.py b/Lib/corpuscrawler/util.py
index f22e6b9..e6b294c 100644
--- a/Lib/corpuscrawler/util.py
+++ b/Lib/corpuscrawler/util.py
@@ -316,7 +316,7 @@ class Crawler(object):
 # using the same site structure for all languages.
 def crawl_bbc_news(crawler, out, urlprefix):
     # sitemap = {'http://www.bbc.com/burmese/world-41146701': None}
-    sitemap = crawler.fetch_sitemap('http://www.bbc.com/sitemap.xml')
+    sitemap = crawler.fetch_sitemap('http://www.bbc.co.uk/sitemap.xml')
     pubdate_regex = re.compile(r'"dateModified":\s*"([0-9T:+\-]{25})"')
     for url in sorted(sitemap.keys()):
         if not urlpath(url).startswith(urlprefix):